### PR TITLE
Add week 5 wiki and Discussions workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - `week1-profile-readme`: GitHub Profile README 초안
 - `week2-dora-metrics`: DORA 지표 자동 수집, 대시보드, 주간 보고서
 - `week3-kanban-project`: Kanban 기반 GitHub Project, 이슈/라벨/마일스톤, 분석 문서
+- `week5-wiki-discussions`: Wiki 초안, ADR 템플릿, Discussions/RFC 운영 가이드
 
 ## 생성형 AI 사용 고지
 이 저장소의 문서들은 생성형 AI(GitHub Copilot)를 활용하여 작성되었습니다.

--- a/docs/adr/0001-template.md
+++ b/docs/adr/0001-template.md
@@ -1,0 +1,30 @@
+# ADR 0001: <Decision Title>
+
+Date: YYYY-MM-DD
+Status: Proposed
+
+## Context
+- 이 결정이 필요한 배경을 적는다.
+- 해결하려는 문제를 한두 문장으로 요약한다.
+
+## Decision
+- 선택한 방안을 적는다.
+- 필요한 경우 범위와 제약을 함께 적는다.
+
+## Alternatives
+- 대안 1과 장단점
+- 대안 2와 장단점
+
+## Consequences
+- 이 결정의 결과로 생기는 장점
+- 감수해야 할 단점 또는 후속 작업
+
+## Links
+- Related Discussion: <RFC discussion link>
+- Related Wiki: [Getting Started](../../week5-wiki-discussions/getting-started.md)
+
+## Notes
+- 필요하면 다음 ADR에서 보완한다.
+
+## 생성형 AI 사용 고지
+이 템플릿은 생성형 AI(GitHub Copilot)를 활용하여 작성되었습니다.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,13 @@
+# ADR Directory
+
+이 디렉터리는 기술결정기록(ADR)을 보관하는 기본 구조입니다.
+
+## 파일 규칙
+- `0001-template.md`: 새 ADR을 시작할 때 복사하는 템플릿
+- `0002-*.md`: 실제 결정 기록
+
+## 시작 문서
+- [ADR Template](0001-template.md)
+
+## 생성형 AI 사용 고지
+이 문서는 생성형 AI(GitHub Copilot)를 활용하여 작성되었습니다.

--- a/docs/discussions-category-plan.md
+++ b/docs/discussions-category-plan.md
@@ -1,0 +1,25 @@
+# Discussions Category Plan
+
+이 문서는 GitHub Discussions에 사용할 카테고리 설계를 정리합니다.
+
+## Category Map
+- Ideas: RFC, 기능 제안, 실험적인 논의
+- Q&A: 사용 방법, 막힌 점, 학습 질문
+- General: 가벼운 대화와 운영 공지 이전 단계의 이야기
+- Announcements: 유지보수 공지와 중요한 업데이트
+- Show and tell: 결과물 공유와 데모
+- Polls: 선택이 필요한 주제에 대한 의견 수렴
+
+## RFC 운영 방식
+- RFC는 우선 Ideas 카테고리로 올린다.
+- 제목은 `RFC: <topic>` 형식을 사용한다.
+- 본문에는 Context, Proposal, Open Questions, Related Docs를 넣는다.
+- 결론이 나면 ADR 또는 위키 문서로 연결한다.
+
+## Why this layout
+- 기존 GitHub 기본 카테고리를 그대로 활용해서 시작 비용을 낮춘다.
+- RFC와 Q&A를 분리해 토론과 지원을 구분한다.
+- 위키와 ADR로 이어지도록 문서 흐름을 단순하게 유지한다.
+
+## 생성형 AI 사용 고지
+이 문서는 생성형 AI(GitHub Copilot)를 활용하여 작성되었습니다.

--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -1,0 +1,15 @@
+# Workflow Drafts
+
+이 디렉터리는 Discussions/RFC와 연결되는 자동화 워크플로 초안을 모아둡니다.
+
+## 초안 목록
+- [Auto Response](auto-response.md)
+- [SLA Tracking](sla-tracking.md)
+- [Weekly Summary](weekly-summary.md)
+
+## 연결 문서
+- [Getting Started](../../week5-wiki-discussions/getting-started.md)
+- [Development Guide](../../week5-wiki-discussions/development-guide.md)
+
+## 생성형 AI 사용 고지
+이 문서는 생성형 AI(GitHub Copilot)를 활용하여 작성되었습니다.

--- a/docs/workflows/auto-response.md
+++ b/docs/workflows/auto-response.md
@@ -1,0 +1,19 @@
+# Auto Response Workflow Draft
+
+## Goal
+새 RFC Discussion이 생성되면 기본 안내와 템플릿 링크를 자동 응답한다.
+
+## Trigger
+- `discussion.created`
+
+## Draft Steps
+1. 새 토론 제목이 RFC 형식인지 확인한다.
+2. 기본 안내 댓글을 남긴다.
+3. ADR 템플릿과 위키 시작 문서를 안내한다.
+
+## Related Docs
+- [Workflow Drafts](README.md)
+- [Getting Started](../../week5-wiki-discussions/getting-started.md)
+
+## 생성형 AI 사용 고지
+이 문서는 생성형 AI(GitHub Copilot)를 활용하여 작성되었습니다.

--- a/docs/workflows/sla-tracking.md
+++ b/docs/workflows/sla-tracking.md
@@ -1,0 +1,21 @@
+# SLA Tracking Workflow Draft
+
+## Goal
+RFC 토론의 첫 응답까지 걸린 시간을 측정해 협업 SLA를 추적한다.
+
+## Metrics
+- First response time
+- Resolution time
+- Open threads older than SLA threshold
+
+## Draft Steps
+1. 새 토론과 첫 댓글의 차이를 계산한다.
+2. SLA를 넘긴 토론을 주간 요약에 포함한다.
+3. 위키의 Troubleshooting 문서에 반복 이슈를 반영한다.
+
+## Related Docs
+- [Workflow Drafts](README.md)
+- [Troubleshooting](../../week5-wiki-discussions/troubleshooting.md)
+
+## 생성형 AI 사용 고지
+이 문서는 생성형 AI(GitHub Copilot)를 활용하여 작성되었습니다.

--- a/docs/workflows/weekly-summary.md
+++ b/docs/workflows/weekly-summary.md
@@ -1,0 +1,21 @@
+# Weekly Summary Workflow Draft
+
+## Goal
+이번 주에 생성된 RFC, 결론, 보류 항목을 한 번에 요약한다.
+
+## Draft Steps
+1. 새 Discussions를 수집한다.
+2. 해결된 토론과 미해결 토론을 분리한다.
+3. 위키와 ADR에 반영할 항목을 목록화한다.
+
+## Output
+- 신규 RFC 수
+- 결론이 난 토론 수
+- 다음 주로 이월된 질문
+
+## Related Docs
+- [Workflow Drafts](README.md)
+- [Development Guide](../../week5-wiki-discussions/development-guide.md)
+
+## 생성형 AI 사용 고지
+이 문서는 생성형 AI(GitHub Copilot)를 활용하여 작성되었습니다.

--- a/week5-wiki-discussions/README.md
+++ b/week5-wiki-discussions/README.md
@@ -1,0 +1,19 @@
+# 5주차 과제 - Wiki 및 Discussions 운영
+
+이 폴더는 GitHub Wiki, ADR 초안, Discussions 기반 RFC 운영을 정리한 5주차 과제 산출물입니다.
+
+## 포함 문서
+- [Getting Started](getting-started.md)
+- [Development Guide](development-guide.md)
+- [Troubleshooting](troubleshooting.md)
+- [Discussion Category Plan](../docs/discussions-category-plan.md)
+- [ADR Template](../docs/adr/0001-template.md)
+- [Workflow Drafts](../docs/workflows/README.md)
+
+## 운영 목표
+- 위키 문서 3개 이상을 상호 링크로 연결한다.
+- 기술결정기록(ADR) 템플릿과 구조를 마련한다.
+- Discussions에서 RFC 형식의 토론을 운영한다.
+
+## 생성형 AI 사용 고지
+이 문서는 생성형 AI(GitHub Copilot)를 활용하여 작성되었습니다.

--- a/week5-wiki-discussions/development-guide.md
+++ b/week5-wiki-discussions/development-guide.md
@@ -1,0 +1,26 @@
+# Development Guide
+
+이 페이지는 5주차에서 필요한 문서/토론/자동화 초안의 운영 기준을 정리합니다.
+
+## 문서 구조
+- [Getting Started](getting-started.md): 시작점과 전체 흐름
+- [Troubleshooting](troubleshooting.md): 자주 막히는 지점과 해결책
+- [ADR Template](../docs/adr/0001-template.md): 결정 기록 형식
+
+## Discussions 운영
+- RFC 형식의 토론 제목을 사용한다.
+- 배경, 문제, 대안, 열린 질문을 본문에 넣는다.
+- 후속 코멘트에는 결정 여부와 작업 항목을 구분해 적는다.
+
+## 자동화 초안
+- 자동 응답 워크플로우: 새 RFC 토론에 기본 안내를 남긴다.
+- SLA 추적 워크플로우: 응답 지연 시간을 수집한다.
+- 주간 요약 워크플로우: 새로 열린 토론과 결론을 요약한다.
+
+## 관련 문서
+- [Getting Started](getting-started.md)
+- [Troubleshooting](troubleshooting.md)
+- [Workflow Drafts](../docs/workflows/README.md)
+
+## 생성형 AI 사용 고지
+이 문서는 생성형 AI(GitHub Copilot)를 활용하여 작성되었습니다.

--- a/week5-wiki-discussions/getting-started.md
+++ b/week5-wiki-discussions/getting-started.md
@@ -1,0 +1,26 @@
+# Getting Started
+
+이 페이지는 5주차 협업 규칙을 처음 보는 사람이 바로 따라올 수 있도록 정리한 시작점입니다.
+
+## 먼저 읽을 문서
+- [Development Guide](development-guide.md)
+- [Troubleshooting](troubleshooting.md)
+- [ADR Template](../docs/adr/0001-template.md)
+
+## 진행 순서
+1. Discussions에서 RFC 토론을 확인한다.
+2. ADR 템플릿으로 결정 배경과 대안을 정리한다.
+3. 위키 문서를 갱신하고 서로 링크를 맞춘다.
+4. 자동 응답, SLA 추적, 주간 요약 워크플로우 초안을 점검한다.
+
+## 권장 체크포인트
+- 브랜치가 `feature/*` 패턴인지 확인한다.
+- 문서 변경은 PR 템플릿을 사용해 리뷰받는다.
+- 위키와 Discussions 링크가 서로 끊기지 않는지 확인한다.
+
+## 다음 문서
+- [Development Guide](development-guide.md)
+- [Troubleshooting](troubleshooting.md)
+
+## 생성형 AI 사용 고지
+이 문서는 생성형 AI(GitHub Copilot)를 활용하여 작성되었습니다.

--- a/week5-wiki-discussions/troubleshooting.md
+++ b/week5-wiki-discussions/troubleshooting.md
@@ -1,0 +1,29 @@
+# Troubleshooting
+
+이 페이지는 위키, Discussions, ADR, 워크플로 초안 작성 중 자주 생기는 문제를 정리합니다.
+
+## 위키가 안 보일 때
+- 저장소 Wiki가 활성화되어 있는지 확인한다.
+- 첫 페이지가 생성되지 않았다면 `Create the first page` 흐름을 사용한다.
+- [Getting Started](getting-started.md)에서 문서 연결 구조를 먼저 확인한다.
+
+## Discussions가 안 열릴 때
+- 저장소 설정에서 Discussions 기능을 활성화한다.
+- 카테고리가 없으면 RFC, Q&A, Announcements처럼 역할을 나눈다.
+- [Development Guide](development-guide.md)의 RFC 형식을 참고한다.
+
+## ADR 작성이 막힐 때
+- [ADR Template](../docs/adr/0001-template.md)를 복사해 시작한다.
+- 결정 배경과 대안은 짧게라도 반드시 기록한다.
+- 후속 문서 링크를 위키와 연결한다.
+
+## 워크플로 초안이 부족할 때
+- [Workflow Drafts](../docs/workflows/README.md)를 기준으로 자동 응답, SLA, 주간 요약을 분리한다.
+- 실제 구현 전에는 트리거와 입력 이벤트를 먼저 정의한다.
+
+## 다음 단계
+- [Getting Started](getting-started.md)
+- [Development Guide](development-guide.md)
+
+## 생성형 AI 사용 고지
+이 문서는 생성형 AI(GitHub Copilot)를 활용하여 작성되었습니다.


### PR DESCRIPTION
## Summary
Add the week 5 wiki and Discussions workflow materials, including wiki-style documentation, ADR templates, workflow drafts, and a Discussions category plan.

## What Changed
- Added `week5-wiki-discussions/README.md` and three linked wiki pages
- Added ADR structure and template under `docs/adr/`
- Added workflow draft docs under `docs/workflows/`
- Added a Discussions category plan for RFC-style usage
- Updated the root README to include the new week 5 folder

## GitHub Results
- Enabled GitHub Discussions for the repository
- Created an RFC discussion in the Ideas category: `RFC: Week 5 wiki and discussions workflow`
- Created the GitHub Wiki pages: Getting Started, Development Guide, Troubleshooting

## Validation
- `git diff --check`
- Pushed the feature branch to origin

## Notes
- The RFC thread is intentionally concise and linked to the wiki/ADR flow.
- Generated with GitHub Copilot.